### PR TITLE
fix: don't overwrite transformed file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,17 @@ export default defineConfig(() => {
 
 ```
 
+## Development
+
+```sh
+# Install all dependencies
+pnpm install
+
+# Build or dev core package
+pnpm --filter vite-plugin-mpa-plus build
+pnpm --filter vite-plugin-mpa-plus dev
+
+# Build playground example
+pnpm --filter playground-mpa build
+
+```

--- a/packages/playground/mpa/package.json
+++ b/packages/playground/mpa/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "playground-map",
+  "name": "playground-mpa",
   "version": "0.0.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/yzydeveloper/vite-plugin-mpa-plus/issues/3

The method is quite similar to a prior commit you have, where we don't write file contents directly. Instead, we let Vite and any userland plugins that exist transform and generate the final HTML files, and on closing the bundle we move each file into it's respective new location.

I'm fairly new to rollup and plugins so please let me know if I should change or adjust something. But the root issue is a significant blocker for me, so hopefully it can get resolved soon. :)