### PR TITLE
fix: Delete "viteConfig.mode" in the "closeBundle" function

### DIFF
--- a/packages/core/src/htmlFixPlugin.ts
+++ b/packages/core/src/htmlFixPlugin.ts
@@ -12,10 +12,6 @@ function slash(p: string): string {
     return p.replace(/\\/g, '/')
 }
 
-function isProduction(mode: string) {
-    return mode === 'production'
-}
-
 function copyFile(
     from: string,
     to: string
@@ -95,7 +91,6 @@ export function createHtmlFixPlugin(options: Options): Plugin {
             })
         },
         closeBundle() {
-            if (!isProduction(viteConfig.mode)) return
             const root = slash(viteConfig.root || process.cwd())
             const dest = slash(viteConfig.build.outDir || 'dist')
 


### PR DESCRIPTION
Fixes https://github.com/yzydeveloper/vite-plugin-mpa-plus/issues/5

[buildEnd](https://rollupjs.org/guide/en/#buildend) are called when the server is closed